### PR TITLE
chore: fix ruff lint warnings

### DIFF
--- a/src/agent_memory_bench/cli.py
+++ b/src/agent_memory_bench/cli.py
@@ -6,15 +6,15 @@ from pathlib import Path
 
 import click
 
+from agent_memory_bench.adapters.base import MemoryAdapter
 from agent_memory_bench.core import BenchmarkRunner, TASK_GENERATORS
-from agent_memory_bench.models import TaskType
 from agent_memory_bench.runner import print_report, save_report
 
 
 AVAILABLE_TASKS = [t.value for t in TASK_GENERATORS]
 
 
-def _resolve_adapter(name: str):
+def _resolve_adapter(name: str) -> MemoryAdapter:
     """Resolve adapter by name, importing and instantiating it."""
     match name:
         case "mem0":
@@ -107,7 +107,6 @@ def adapters():
 def report(input_file, output):
     """Generate a leaderboard report from a previous benchmark run."""
     import json
-    from agent_memory_bench.models import BenchmarkReport
 
     data = json.loads(Path(input_file).read_text())
     click.echo(f"Leaderboard from {data.get('timestamp', 'unknown')}:\n")

--- a/src/agent_memory_bench/core.py
+++ b/src/agent_memory_bench/core.py
@@ -117,12 +117,12 @@ def generate_temporal_reasoning_task(num_samples: int = 10, seed: int = 42) -> T
         # Create a sequence of events
         events = [
             MemoryEntry(
-                content=f"User set their favorite color to blue.",
+                content="User set their favorite color to blue.",
                 timestamp=base_time + timedelta(days=i * 10),
                 metadata={"type": "preference", "version": 1},
             ),
             MemoryEntry(
-                content=f"User changed their favorite color to green.",
+                content="User changed their favorite color to green.",
                 timestamp=base_time + timedelta(days=i * 10 + 5),
                 metadata={"type": "preference", "version": 2},
             ),

--- a/src/agent_memory_bench/runner.py
+++ b/src/agent_memory_bench/runner.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from rich.console import Console
 from rich.table import Table
 
-from agent_memory_bench.core import BenchmarkRunner
 from agent_memory_bench.models import BenchmarkReport
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -10,14 +10,7 @@ from agent_memory_bench.core import (
     generate_fact_recall_task,
     generate_temporal_reasoning_task,
 )
-from agent_memory_bench.models import (
-    BenchmarkReport,
-    MemoryEntry,
-    Query,
-    SampleResult,
-    TaskResult,
-    TaskType,
-)
+from agent_memory_bench.models import BenchmarkReport, SampleResult, TaskResult, TaskType
 
 
 class TestMetrics:


### PR DESCRIPTION
## Summary
- remove unused imports and redundant f-strings reported by ruff
- add missing return type annotation for adapter resolver

## Rationale
- clean lint baseline so future work starts from zero ruff errors

## Changes
- cli: add MemoryAdapter import, annotate _resolve_adapter, drop unused import and local BenchmarkReport import
- core: remove f-prefix on constant strings
- runner/tests: remove unused imports flagged by ruff

Fixes #3

No tests added; behavior unchanged.